### PR TITLE
Add ability to customize time text

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ These endpoints always return the same response for testing.
 
 Config is done via environment variables passed to the container.
 
-| ENV             | Description                                                             | Default            |
-| --------------- | ----------------------------------------------------------------------- | ------------------ |
-| `TEAM_ABBREV`   | Team abbreviation (e.g. BOS, NYR, SEA)                                  | `BOS`              |
-| `ANNOUNCE_NAME` | The name for use in the announcement (e.g. "Boston goal, scored by...") | `Boston`           |
-| `TZ_NAME`       | Timezone string (e.g. America/New_York)                                 | `America/New_York` |
-| `PORT`          | Port for the web app                                                    | `3000`             |
-| `DEBUG`         | Enable debug logging                                                    | `false`            |
+| ENV             | OPTIONS                                                                       | DEFAULT            | DESCRIPTION                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEAM_ABBREV`   | see below                                                                     | `BOS`              | Team abbreviation                                                                                                                                                           |
+| `ANNOUNCE_NAME` | anything                                                                      | `Boston`           | The name for use in the announcement (e.g. "Boston goal, scored by...")                                                                                                     |
+| `TIME_ANNOUNCE` | `raw`, `human`                                                                | `raw`              | The way the time is written in the announcement. `raw` is the exact value: "12:03", `human` is the more human literal way to say it: "12 oh 3" (to help with TTS services). |
+| `TZ_NAME`       | [TZ Identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) | `America/New_York` | Timezone string (e.g. America/New_York)                                                                                                                                     |
+| `PORT`          | 1-65535                                                                       | `3000`             | Port for the web app                                                                                                                                                        |
+| `DEBUG`         | `true`, `false`                                                               | `false`            | Enable debug logging                                                                                                                                                        |
+
+`TEAM_ABBREV: `ANA`,`ARI`,`BOS`,`BUF`,`CAR`,`CBJ`,`CGY`,`CHI`,`COL`,`DAL`,`DET`,`EDM`,`FLA`,`LAK`,`MIN`,`MTL`,`NJD`,`NSH`,`NYI`,`NYR`,`OTT`,`PHI`,`PIT`,`SEA`,`SJS`,`STL`,`TBL`,`TOR`,`UTA`,`VAN`,`VGS`,`WPG`,`WSH`

--- a/app.js
+++ b/app.js
@@ -50,32 +50,32 @@ app.get('/demo/announce', (req, res) => {
 
 app.get('/demo/goal', (req, res) => {
   res.send({
-  status: "GOAL",
-  data: {
-    announcement: "Boston goal, scored by number 28, Elias Lindholm. Assisted by number 18 Pavel Zacha and number 88 David Pastrnak. Time of the goal 15 seconds. Lindholm's 2nd goal of the season from Zach and Pastranak at 15 seconds.",
-    shortText: "Lindholm (2nd), Zacha (A) Pastrnak (A) @ 15s",
-    name: "Elias Lindholm",
-    firstName: "Elias",
-    lastName: "Lindholm",
-    number: "28",
-    timeOfGoal: "00:15",
-    goalNumber: "2nd",
-    assists: [
-      {
-        name: "Pavel Zacha",
-        firstName: "Pavel",
-        lastName: "Zacha",
-        number: "18"
-      },
-      {
-        name: "David Pastrnak",
-        firstName: "David",
-        lastName: "Pastrnak",
-        number: "88"
-      }
-    ]
-  }
-})
+    status: "GOAL",
+    data: {
+      announcement: "Boston goal, scored by number 28, Elias Lindholm. Assisted by number 18 Pavel Zacha and number 88 David Pastrnak. Time of the goal 15 seconds. Lindholm's 2nd goal of the season from Zach and Pastranak at 15 seconds.",
+      shortText: "Lindholm (2nd), Zacha (A) Pastrnak (A) @ 15s",
+      name: "Elias Lindholm",
+      firstName: "Elias",
+      lastName: "Lindholm",
+      number: "28",
+      timeOfGoal: "00:15",
+      goalNumber: "2nd",
+      assists: [
+        {
+          name: "Pavel Zacha",
+          firstName: "Pavel",
+          lastName: "Zacha",
+          number: "18"
+        },
+        {
+          name: "David Pastrnak",
+          firstName: "David",
+          lastName: "Pastrnak",
+          number: "88"
+        }
+      ]
+    }
+  })
 });
 
 

--- a/nhl.js
+++ b/nhl.js
@@ -152,18 +152,20 @@ export async function getGoalAnnouncement(gameId, announceName, team) {
             assists: []
           };
 
+          let pTime = utils.timeToSpeech(mostRecentTeamGoal.timeInPeriod);
+
           if (mostRecentTeamGoal.assists.length === 2) {
             let assist1 = `number ${mostRecentTeamGoal.assists[0].sweaterNumber} ${mostRecentTeamGoal.assists[0].firstName.default} ${mostRecentTeamGoal.assists[0].lastName.default}`;
             let assist2 = `number ${mostRecentTeamGoal.assists[1].sweaterNumber} ${mostRecentTeamGoal.assists[1].firstName.default} ${mostRecentTeamGoal.assists[1].lastName.default}`;
-            
+
             if (ppg) {
-              fullAnnounce = `${announceName}, power play goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName}, power play goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${pTime}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${pTime}.`;
               shortText = `PPG: ${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} & ${mostRecentTeamGoal.assists[1].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else if (shg) {
-              fullAnnounce = `${announceName} goal, short handed, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, short handed, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${pTime}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${pTime}.`;
               shortText = `SHG: ${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} & ${mostRecentTeamGoal.assists[1].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else {
-              fullAnnounce = `${announceName} goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1} and ${assist2}. Time of the goal ${pTime}... That's ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} and ${mostRecentTeamGoal.assists[1].lastName.default}, at ${pTime}.`;
               shortText = `${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} & ${mostRecentTeamGoal.assists[1].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             }
 
@@ -180,15 +182,15 @@ export async function getGoalAnnouncement(gameId, announceName, team) {
 
           } else if (mostRecentTeamGoal.assists.length === 1) {
             let assist1 = `number ${mostRecentTeamGoal.assists[0].sweaterNumber} ${mostRecentTeamGoal.assists[0].firstName.default} ${mostRecentTeamGoal.assists[0].lastName.default}`;
-            
+
             if (ppg) {
-              fullAnnounce = `${announceName}, power play goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName}, power play goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${pTime}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${pTime}.`;
               shortText = `PPG: ${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else if (shg) {
-              fullAnnounce = `${announceName} goal, short handed, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, short handed, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${pTime}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${pTime}.`;
               shortText = `SHG: ${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else {
-              fullAnnounce = `${announceName} goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, scored by number ${goalSweater}, ${scoredBy}. Assisted by ${assist1}. Time of the goal ${pTime}. ${goalLast}'s ${goalCount} goal of the season from ${mostRecentTeamGoal.assists[0].lastName.default} at ${pTime}.`;
               shortText = `${goalLast} (${goalCount}), ${mostRecentTeamGoal.assists[0].lastName.default} (A) @ ${mostRecentTeamGoal.timeInPeriod}`;
             }
 
@@ -204,13 +206,13 @@ export async function getGoalAnnouncement(gameId, announceName, team) {
           } else {
 
             if (ppg) {
-              fullAnnounce = `${announceName}, power play goal, an unassisted goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. That's ${goalLast}'s ${goalCount} goal of the season at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName}, power play goal, an unassisted goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${pTime}. That's ${goalLast}'s ${goalCount} goal of the season at ${pTime}.`;
               shortText = `PPG: ${goalLast} (${goalCount}) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else if (shg) {
-              fullAnnounce = `${announceName} goal, an unassisted short handed goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. That's ${goalLast}'s ${goalCount} goal of the season at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, an unassisted short handed goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${pTime}. That's ${goalLast}'s ${goalCount} goal of the season at ${pTime}.`;
               shortText = `SHG: ${goalLast} (${goalCount}) @ ${mostRecentTeamGoal.timeInPeriod}`;
             } else {
-              fullAnnounce = `${announceName} goal, an unassisted goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${mostRecentTeamGoal.timeInPeriod}. That's ${goalLast}'s ${goalCount} goal of the season at ${mostRecentTeamGoal.timeInPeriod}.`;
+              fullAnnounce = `${announceName} goal, an unassisted goal, scored by number ${goalSweater}, ${scoredBy}. Time of the goal ${pTime}. That's ${goalLast}'s ${goalCount} goal of the season at ${pTime}.`;
               shortText = `${goalLast} (${goalCount}) @ ${mostRecentTeamGoal.timeInPeriod}`;
             }
 

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 const DEBUG = process.env.DEBUG || false;
-const TIME_ANNOUNCE = process.env.TIME_ANNOUNCE || 'human';
+const TIME_ANNOUNCE = process.env.TIME_ANNOUNCE || 'raw';
 
 export function getOrdinal(n) {
   let ord = 'th';

--- a/utils.js
+++ b/utils.js
@@ -78,8 +78,20 @@ export function getLocalDate(tzString) {
 };
 
 export function timeToSpeech(rawTime) {
-  const [minutes, seconds] = rawTime.split(':').map(Number);
+  // Validate input before attempting to split
+  if (typeof rawTime !== 'string' || !rawTime.includes(':')) {
+    // For invalid inputs, avoid throwing and return a safe fallback
+    return rawTime == null ? '' : String(rawTime);
+  }
 
+  const [minutesStr, secondsStr] = rawTime.split(':');
+  const minutes = Number(minutesStr);
+  const seconds = Number(secondsStr);
+
+  // If parsing fails, fall back to returning the original value
+  if (Number.isNaN(minutes) || Number.isNaN(seconds)) {
+    return rawTime;
+  }
   if (seconds === 0) {
     return `${Number(minutes)} minutes`;
   } else if (minutes === 0) {

--- a/utils.js
+++ b/utils.js
@@ -93,16 +93,16 @@ export function timeToSpeech(rawTime) {
     return rawTime;
   }
   if (seconds === 0) {
-    return `${Number(minutes)} minutes`;
+    return `${minutes} minutes`;
   } else if (minutes === 0) {
     return `${seconds} seconds`;
   } else if (TIME_ANNOUNCE === 'raw') {
     return rawTime;
   } else if (TIME_ANNOUNCE === 'human') {
     if (seconds < 10) {
-      return `${Number(minutes)} oh ${seconds}`;
+      return `${minutes} oh ${seconds}`;
     }
-    return `${Number(minutes)} ${seconds}`;
+    return `${minutes} ${seconds}`;
   } else {
     return rawTime;
   };

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 const DEBUG = process.env.DEBUG || false;
+const TIME_ANNOUNCE = process.env.TIME_ANNOUNCE || 'human';
 
 export function getOrdinal(n) {
   let ord = 'th';
@@ -75,3 +76,22 @@ export function getLocalDate(tzString) {
   const isoString = `${dateTime.year}-${dateTime.month}-${dateTime.day}`;
   return isoString
 };
+
+export function timeToSpeech(rawTime) {
+  const [minutes, seconds] = rawTime.split(':').map(Number);
+
+  if (seconds === 0) {
+    return `${Number(minutes)} minutes`;
+  } else if (minutes === 0) {
+    return `${seconds} seconds`;
+  } else if (TIME_ANNOUNCE === 'raw') {
+    return rawTime;
+  } else if (TIME_ANNOUNCE === 'human') {
+    if (seconds < 10) {
+      return `${Number(minutes)} oh ${seconds}`;
+    }
+    return `${Number(minutes)} ${seconds}`;
+  } else {
+    return rawTime;
+  };
+}


### PR DESCRIPTION
Closes #5 

There's cases where an LLM doesn't read raw times correctly (ex: reading "11:03" as "eleven colon oh three" or "11:00" as "eleven o'clock". 

A new ENV is introduced to control this behavior, with the default being the raw value (same as `raw` option).

If you specify `human`, it will change the announcement text to be more human literal. This does not affect "shortText" or any of the raw data.